### PR TITLE
Use symlink instead of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test-resource/android-platforms"]
-	path = test-resource/android-platforms
-	url = https://github.com/izgzhen/android-platforms

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # soot-skeleton
 Automatically enumerates some options in a Soot based on user determined example output and input and generates a starter script.
 
-Initialize submodule:
+Symlink the `android-platforms` folder (https://github.com/izgzhen/android-platforms):
 
 ```
-git submodule update --init
+ln -s path/to/android-platforms test-resource
 ```
+
 For more resources, please check wiki.


### PR DESCRIPTION
This makes it easier to share the single local copy of android-platforms. Sorry for the regression here.